### PR TITLE
feat/PN-14927 - Manage new optional 'data' param

### DIFF
--- a/docs/openapi/api-external-web-cittadino.yaml
+++ b/docs/openapi/api-external-web-cittadino.yaml
@@ -59,6 +59,13 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
+        data:
+          description: >-
+            Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
+          type: string
+          maxLength: 600
+      required:
+        - email
     NewSupportResponse:
       required:
         - action_url

--- a/docs/openapi/api-external-web-cittadino.yaml
+++ b/docs/openapi/api-external-web-cittadino.yaml
@@ -1,4 +1,8 @@
 openapi: 3.0.3
+info:
+  title: ZendeskAuthorization API
+  description: API per la creazione di richieste di supporto
+  version: 1.0.0
 tags:
   - name: SupportRequest
     description: >-
@@ -59,13 +63,16 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        traceId:
+        data:
           description: >-
-            Campo opzionale contenente il trace id da passare alla richiesta di supporto
-          type: string
-          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
-          minLength: 35
-          maxLength: 35
+            Oggetto opzionale contenente dati tecnici da passare alla richiesta di supporto
+          type: object
+          properties:
+            traceId:
+              type: string
+              pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
+              minLength: 35
+              maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-external-web-cittadino.yaml
+++ b/docs/openapi/api-external-web-cittadino.yaml
@@ -73,6 +73,12 @@ components:
               pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
               minLength: 35
               maxLength: 35
+            errorCode:
+              type: string
+              pattern: ^[A-Z_]+$
+              maxLength: 100
+          required:
+            - traceId
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-external-web-cittadino.yaml
+++ b/docs/openapi/api-external-web-cittadino.yaml
@@ -59,11 +59,13 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        data:
+        traceId:
           description: >-
-            Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
+            Campo opzionale contenente il trace id da passare alla richiesta di supporto
           type: string
-          maxLength: 600
+          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
+          minLength: 35
+          maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -13,41 +13,41 @@ paths:
       tags:
         - SupportRequest
       operationId: newSupportRequest
-#      security:                                      # ONLY EXTERNAL
-#        - bearerAuth: [ ]                            # ONLY EXTERNAL
-      x-pagopa-lambda-name: 'pn-zendesk-authorization-lambda'
+      #      security:                                      # ONLY EXTERNAL
+      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      x-pagopa-lambda-name: "pn-zendesk-authorization-lambda"
       x-pagopa-lambda-account: core
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewSupportRequest'
+              $ref: "#/components/schemas/NewSupportRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: ok
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NewSupportResponse'
-        '400':
+                $ref: "#/components/schemas/NewSupportResponse"
+        "400":
           description: Invalid input
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/Problem'
-        '403':
+                $ref: "#/components/schemas/Problem"
+        "403":
           description: Forbidden
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/Problem'
-        '500':
+                $ref: "#/components/schemas/Problem"
+        "500":
           description: Internal Server Error
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/Problem'
+                $ref: "#/components/schemas/Problem"
 
 components:
   schemas:
@@ -59,6 +59,13 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
+        data:
+          description: >-
+            Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
+          type: string
+          maxLength: 600
+      required:
+        - email
     NewSupportResponse:
       required:
         - action_url
@@ -112,7 +119,7 @@ components:
           type: array
           minItems: 1
           items:
-            $ref: '#/components/schemas/ProblemError'
+            $ref: "#/components/schemas/ProblemError"
       required:
         - status
         - errors
@@ -124,7 +131,7 @@ components:
           type: string
         element:
           description: Parameter or request body field name for validation error
-          example: 'body.order.item[2].quantity'
+          example: "body.order.item[2].quantity"
           type: string
         detail:
           description: A human readable explanation specific to this occurrence of the problem.

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -64,7 +64,8 @@ components:
             Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
           type: string
           pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
-          maxLength: 600
+          minLength: 35
+          maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -59,9 +59,9 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        data:
+        traceId:
           description: >-
-            Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
+            Campo opzionale contenente il trace id da passare alla richiesta di supporto
           type: string
           pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
           minLength: 35

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -1,4 +1,8 @@
 openapi: 3.0.3
+info:
+  title: ZendeskAuthorization API
+  description: API per la creazione di richieste di supporto
+  version: 1.0.0
 tags:
   - name: SupportRequest
     description: >-
@@ -59,13 +63,16 @@ components:
           type: string
           pattern: ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        traceId:
+        data:
           description: >-
-            Campo opzionale contenente il trace id da passare alla richiesta di supporto
-          type: string
-          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
-          minLength: 35
-          maxLength: 35
+            Oggetto opzionale contenente dati tecnici da passare alla richiesta di supporto
+          type: object
+          properties:
+            traceId:
+              type: string
+              pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
+              minLength: 35
+              maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -73,6 +73,12 @@ components:
               pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
               minLength: 35
               maxLength: 35
+            errorCode:
+              type: string
+              pattern: ^[A-Z_]+$
+              maxLength: 100
+          required:
+            - traceId
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -13,41 +13,41 @@ paths:
       tags:
         - SupportRequest
       operationId: newSupportRequest
-      #      security:                                      # ONLY EXTERNAL
-      #        - bearerAuth: [ ]                            # ONLY EXTERNAL
-      x-pagopa-lambda-name: "pn-zendesk-authorization-lambda"
+#      security:                                      # ONLY EXTERNAL
+#        - bearerAuth: [ ]                            # ONLY EXTERNAL
+      x-pagopa-lambda-name: 'pn-zendesk-authorization-lambda'
       x-pagopa-lambda-account: core
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewSupportRequest"
+              $ref: '#/components/schemas/NewSupportRequest'
         required: true
       responses:
-        "200":
+        '200':
           description: ok
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NewSupportResponse"
-        "400":
+                $ref: '#/components/schemas/NewSupportResponse'
+        '400':
           description: Invalid input
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
-        "403":
+                $ref: '#/components/schemas/Problem'
+        '403':
           description: Forbidden
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
-        "500":
+                $ref: '#/components/schemas/Problem'
+        '500':
           description: Internal Server Error
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
+                $ref: '#/components/schemas/Problem'
 
 components:
   schemas:
@@ -119,7 +119,7 @@ components:
           type: array
           minItems: 1
           items:
-            $ref: "#/components/schemas/ProblemError"
+            $ref: '#/components/schemas/ProblemError'
       required:
         - status
         - errors
@@ -131,7 +131,7 @@ components:
           type: string
         element:
           description: Parameter or request body field name for validation error
-          example: "body.order.item[2].quantity"
+          example: 'body.order.item[2].quantity'
           type: string
         detail:
           description: A human readable explanation specific to this occurrence of the problem.

--- a/docs/openapi/api-internal-web-cittadino.yaml
+++ b/docs/openapi/api-internal-web-cittadino.yaml
@@ -63,6 +63,7 @@ components:
           description: >-
             Campo opzionale contenente dati tecnici da passare alla richiesta di supporto
           type: string
+          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
           maxLength: 600
       required:
         - email

--- a/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
+++ b/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: osXXsdFZg2pVvcDzI814gZixCzTgLSnBWKJU60TdZd4=
+  version: ABXrVMaIQJmsxuN5H2peqMOWNl1QNVOgkWcjXxpk020=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -108,6 +108,12 @@ components:
               pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
               minLength: 35
               maxLength: 35
+            errorCode:
+              type: string
+              pattern: ^[A-Z_]+$
+              maxLength: 100
+          required:
+            - traceId
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
+++ b/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: qkAXtL4EpgAdlwqkSyoaSvyUIPmWvIqa00Moy0b3w74=
+  version: osXXsdFZg2pVvcDzI814gZixCzTgLSnBWKJU60TdZd4=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -97,14 +97,17 @@ components:
           pattern: >-
             ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        traceId:
+        data:
           description: >-
-            Campo opzionale contenente il trace id da passare alla richiesta di
-            supporto
-          type: string
-          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
-          minLength: 35
-          maxLength: 35
+            Oggetto opzionale contenente dati tecnici da passare alla richiesta
+            di supporto
+          type: object
+          properties:
+            traceId:
+              type: string
+              pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
+              minLength: 35
+              maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
+++ b/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: RTxpc0Y0WIayU1N7cinFZNjWRquA2XN0ISBLyD2rgEc=
+  version: qkAXtL4EpgAdlwqkSyoaSvyUIPmWvIqa00Moy0b3w74=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -97,12 +97,14 @@ components:
           pattern: >-
             ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
-        data:
+        traceId:
           description: >-
-            Campo opzionale contenente dati tecnici da passare alla richiesta di
+            Campo opzionale contenente il trace id da passare alla richiesta di
             supporto
           type: string
-          maxLength: 600
+          pattern: ^([1-9])-[0-9a-f]{8}-[0-9a-f]{24}$
+          minLength: 35
+          maxLength: 35
       required:
         - email
     NewSupportResponse:

--- a/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
+++ b/docs/openapi/aws/api-zendesk-auth-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: mNYZv0YRjeLq8s0RPunmEW6nUkGodKS9c52rDA1OEDc=
+  version: RTxpc0Y0WIayU1N7cinFZNjWRquA2XN0ISBLyD2rgEc=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -67,7 +67,7 @@ paths:
           integration.request.header.x-pagopa-pn-cx-type: context.authorizer.cx_type
           integration.request.header.x-pagopa-pn-cx-groups: context.authorizer.cx_groups
           integration.request.header.x-pagopa-pn-src-ch-details: context.authorizer.sourceChannelDetails
-          integration.request.header.x-pagopa-pn-src-ch: '''WEB'''
+          integration.request.header.x-pagopa-pn-src-ch: context.authorizer.sourceChannel
         passthroughBehavior: when_no_match
         contentHandling: CONVERT_TO_TEXT
         timeoutInMillis: 29000
@@ -97,6 +97,14 @@ components:
           pattern: >-
             ^([a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10}))$
           maxLength: 320
+        data:
+          description: >-
+            Campo opzionale contenente dati tecnici da passare alla richiesta di
+            supporto
+          type: string
+          maxLength: 600
+      required:
+        - email
     NewSupportResponse:
       required:
         - action_url
@@ -189,7 +197,7 @@ components:
         authorizerUri: >-
           arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:pn-jwtAuthorizerLambda/invocations
         authorizerResultTtlInSeconds: 300
-        identityValidationExpression: ^Bearer\s([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)\.([a-zA-Z0-9_\-]+)$
+        identityValidationExpression: ^Bearer\s([a-zA-Z0-9_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9_\-]+)$
         type: token
 tags:
   - name: SupportRequest
@@ -198,12 +206,16 @@ x-amazon-apigateway-gateway-responses:
   DEFAULT_5XX:
     responseParameters:
       gatewayresponse.header.Access-Control-Allow-Origin: '''*'''
+      gatewayresponse.header.Strict-Transport-Security: '''max-age=31536000; includeSubDomains; preload'''
   DEFAULT_4XX:
     responseParameters:
       gatewayresponse.header.Access-Control-Allow-Origin: '''*'''
+      gatewayresponse.header.Strict-Transport-Security: '''max-age=31536000; includeSubDomains; preload'''
   BAD_REQUEST_PARAMETERS:
     responseParameters:
       gatewayresponse.header.Access-Control-Allow-Origin: '''*'''
+      gatewayresponse.header.Access-Control-Expose-Headers: '''x-amzn-trace-id'''
+      gatewayresponse.header.Strict-Transport-Security: '''max-age=31536000; includeSubDomains; preload'''
     responseTemplates:
       application/json: >-
         {"status": 400, "title": "VALIDATION ERROR", "traceId":
@@ -212,6 +224,8 @@ x-amazon-apigateway-gateway-responses:
   BAD_REQUEST_BODY:
     responseParameters:
       gatewayresponse.header.Access-Control-Allow-Origin: '''*'''
+      gatewayresponse.header.Access-Control-Expose-Headers: '''x-amzn-trace-id'''
+      gatewayresponse.header.Strict-Transport-Security: '''max-age=31536000; includeSubDomains; preload'''
     responseTemplates:
       application/json: >-
         {"status": 400, "title": "VALIDATION ERROR", "traceId":

--- a/functions/zendeskAuthorizer/src/app/eventHandler.js
+++ b/functions/zendeskAuthorizer/src/app/eventHandler.js
@@ -88,7 +88,7 @@ exports.handleEvent = async (event) => {
 		userId = decodedToken?.payload.uid;
 		const requestBody = JSON.parse(event?.body);
 		userEmail = requestBody?.email;
-		data = requestBody?.data;
+		data = requestBody?.traceId;
 	} catch (err) {
 		console.error("Unable to get user information input", err);
 		return createResponse(

--- a/functions/zendeskAuthorizer/src/app/eventHandler.js
+++ b/functions/zendeskAuthorizer/src/app/eventHandler.js
@@ -1,111 +1,151 @@
 const utils = require("./utils");
 
 function getCommonHeaders(allowedOrigin) {
-    return {
-        "Access-Control-Allow-Origin": allowedOrigin,
-        "Access-Control-Allow-Headers": "Content-Type,Authorization",
-        "Access-Control-Allow-Methods": "POST",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-    };
+	return {
+		"Access-Control-Allow-Origin": allowedOrigin,
+		"Access-Control-Allow-Headers": "Content-Type,Authorization",
+		"Access-Control-Allow-Methods": "POST",
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+	};
 }
 
-function createResponse(statusCode, allowedOrigin, body = '', additionalHeaders = {}) {
-    return {
-        statusCode,
-        headers: {
-            ...getCommonHeaders(allowedOrigin),
-            ...additionalHeaders
-        },
-        body: typeof body === 'string' ? body : JSON.stringify(body)
-    };
+function createResponse(
+	statusCode,
+	allowedOrigin,
+	body = "",
+	additionalHeaders = {}
+) {
+	return {
+		statusCode,
+		headers: {
+			...getCommonHeaders(allowedOrigin),
+			...additionalHeaders,
+		},
+		body: typeof body === "string" ? body : JSON.stringify(body),
+	};
 }
 
 exports.handleEvent = async (event) => {
-    const allowedOrigin = event.headers.origin;
-    
-    // Verifica origine trusted
-    if (!utils.isTrustedOrigin(allowedOrigin, process.env.CORS_ALLOWED_DOMAINS)) {
-        const message = "Untrusted origin " + allowedOrigin;
-        console.info("Event: ", utils.removeSensibleInfoFromEvent(event));
-        return createResponse(403, allowedOrigin, utils.generateProblem(403, message));
-    }
+	const allowedOrigin = event.headers.origin;
 
-    // Gestione OPTIONS
-    if (event.httpMethod === 'OPTIONS') {
-        return createResponse(200, allowedOrigin, '');
-    }
+	// Verifica origine trusted
+	if (!utils.isTrustedOrigin(allowedOrigin, process.env.CORS_ALLOWED_DOMAINS)) {
+		const message = "Untrusted origin " + allowedOrigin;
+		console.info("Event: ", utils.removeSensibleInfoFromEvent(event));
+		return createResponse(
+			403,
+			allowedOrigin,
+			utils.generateProblem(403, message)
+		);
+	}
 
-    // Recupero secrets
-    let zendeskSecret, pdvSecret;
-    
-    try {
-        if (process.env.ZENDESK_SECRET_ARN) {
-            const secret = await utils.getSecretFromManager(process.env.ZENDESK_SECRET_ARN);
-            zendeskSecret = secret['sso_secret'];
-        }
-        
-        if (process.env.PDV_SECRET_ARN) {
-            const secret = await utils.getSecretFromManager(process.env.PDV_SECRET_ARN);
-            pdvSecret = secret['UserRegistryApiKeyForPF'];
-        }
-    } catch(ex) {
-        return createResponse(500, allowedOrigin, utils.generateProblem(500, ex.message));
-    }
+	// Gestione OPTIONS
+	if (event.httpMethod === "OPTIONS") {
+		return createResponse(200, allowedOrigin, "");
+	}
 
-    // Decodifica token
-    let decodedToken;
-    try { 
-        const encodedToken = event.headers.Authorization.replace("Bearer ", "");
-        decodedToken = utils.decodeToken(encodedToken);
-    } catch(err) {
-        return createResponse(500, allowedOrigin, utils.generateProblem(500, err.message));
-    }
-    
-    // Recupero informazioni utente
-    let userId, userEmail;
-    try {
-        userId = decodedToken?.payload.uid;
-        const requestBody = JSON.parse(event?.body);
-        userEmail = requestBody?.email;
-    } catch(err) {
-        console.error("Unable to get user information input", err);
-        return createResponse(500, allowedOrigin, utils.generateProblem(500, err.message));
-    }
-    
-    // Recupero informazioni da PDV
-    let userName, userTaxId;
-    if(process.env.PDV_USER_REGISTRY_URL) {
-        const fieldsToRetrieve = ['name', 'familyName', 'fiscalCode'];
-        try {
-            const userResource = await utils.getUserById(
-                process.env.PDV_USER_REGISTRY_URL, 
-                pdvSecret, 
-                userId,
-                fieldsToRetrieve
-            );
-            userName = userResource.name.value + ' ' + userResource.familyName.value;
-            userTaxId = userResource.fiscalCode;
-        } catch(err) {
-            return createResponse(500, allowedOrigin, utils.generateProblem(500, err.message));
-        }
-    }
+	// Recupero secrets
+	let zendeskSecret, pdvSecret;
 
-    // Generazione JWT per Zendesk
-    let jwtZendesk;
-    try {
-        jwtZendesk = utils.generateToken(userName, userEmail, userTaxId, zendeskSecret);
-    } catch(err) {
-        return createResponse(500, allowedOrigin, utils.generateProblem(500, err.message));
-    }
+	try {
+		if (process.env.ZENDESK_SECRET_ARN) {
+			const secret = await utils.getSecretFromManager(
+				process.env.ZENDESK_SECRET_ARN
+			);
+			zendeskSecret = secret["sso_secret"];
+		}
 
-    // Preparazione risposta finale
-    const helpCenterUrl = process.env.HELP_CENTER_URL;
-    const productId = process.env.PRODUCT_ID;
-    const returnBody = {
-        action_url: process.env.ACTION_URL,
-        jwt: jwtZendesk,
-        return_to: `${helpCenterUrl}?product=${productId}`
-    };
-    
-    return createResponse(200, allowedOrigin, returnBody);
+		if (process.env.PDV_SECRET_ARN) {
+			const secret = await utils.getSecretFromManager(
+				process.env.PDV_SECRET_ARN
+			);
+			pdvSecret = secret["UserRegistryApiKeyForPF"];
+		}
+	} catch (ex) {
+		return createResponse(
+			500,
+			allowedOrigin,
+			utils.generateProblem(500, ex.message)
+		);
+	}
+
+	// Decodifica token
+	let decodedToken;
+	try {
+		const encodedToken = event.headers.Authorization.replace("Bearer ", "");
+		decodedToken = utils.decodeToken(encodedToken);
+	} catch (err) {
+		return createResponse(
+			500,
+			allowedOrigin,
+			utils.generateProblem(500, err.message)
+		);
+	}
+
+	// Recupero informazioni utente
+	let userId, userEmail, data;
+	try {
+		userId = decodedToken?.payload.uid;
+		const requestBody = JSON.parse(event?.body);
+		userEmail = requestBody?.email;
+		data = requestBody?.data;
+	} catch (err) {
+		console.error("Unable to get user information input", err);
+		return createResponse(
+			500,
+			allowedOrigin,
+			utils.generateProblem(500, err.message)
+		);
+	}
+
+	// Recupero informazioni da PDV
+	let userName, userTaxId;
+	if (process.env.PDV_USER_REGISTRY_URL) {
+		const fieldsToRetrieve = ["name", "familyName", "fiscalCode"];
+		try {
+			const userResource = await utils.getUserById(
+				process.env.PDV_USER_REGISTRY_URL,
+				pdvSecret,
+				userId,
+				fieldsToRetrieve
+			);
+			userName = userResource.name.value + " " + userResource.familyName.value;
+			userTaxId = userResource.fiscalCode;
+		} catch (err) {
+			return createResponse(
+				500,
+				allowedOrigin,
+				utils.generateProblem(500, err.message)
+			);
+		}
+	}
+
+	// Generazione JWT per Zendesk
+	let jwtZendesk;
+	try {
+		jwtZendesk = utils.generateToken(
+			userName,
+			userEmail,
+			userTaxId,
+			zendeskSecret
+		);
+	} catch (err) {
+		return createResponse(
+			500,
+			allowedOrigin,
+			utils.generateProblem(500, err.message)
+		);
+	}
+
+	// Preparazione risposta finale
+	const helpCenterUrl = process.env.HELP_CENTER_URL;
+	const productId = process.env.PRODUCT_ID;
+	const dataQueryStr = data ? `&data=${data}` : "";
+	const returnBody = {
+		action_url: process.env.ACTION_URL,
+		jwt: jwtZendesk,
+		return_to: `${helpCenterUrl}?product=${productId}${dataQueryStr}`,
+	};
+
+	return createResponse(200, allowedOrigin, returnBody);
 };

--- a/functions/zendeskAuthorizer/src/app/eventHandler.js
+++ b/functions/zendeskAuthorizer/src/app/eventHandler.js
@@ -88,7 +88,7 @@ exports.handleEvent = async (event) => {
 		userId = decodedToken?.payload.uid;
 		const requestBody = JSON.parse(event?.body);
 		userEmail = requestBody?.email;
-		data = requestBody?.traceId;
+		data = requestBody?.data;
 	} catch (err) {
 		console.error("Unable to get user information input", err);
 		return createResponse(
@@ -140,7 +140,7 @@ exports.handleEvent = async (event) => {
 	// Preparazione risposta finale
 	const helpCenterUrl = process.env.HELP_CENTER_URL;
 	const productId = process.env.PRODUCT_ID;
-	const dataQueryStr = data ? `&data=${data}` : "";
+	const dataQueryStr = data ? `&data=${encodeURIComponent(JSON.stringify(data))}` : "";
 	const returnBody = {
 		action_url: process.env.ACTION_URL,
 		jwt: jwtZendesk,

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -47,7 +47,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 			},
 			body: JSON.stringify({
 				email: "test@email.com",
-				data: traceId,
+				traceId,
 			}),
 		};
 

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -37,7 +37,9 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 	});
 
 	it("should include data in return_to when data is provided", async () => {
-		const traceId = '1-67bf00c8-35bf5bec6440ab13382ad7ee';
+		const data = {
+			traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee'
+		};
 		const event = {
 			headers: {
 				origin: "https://cittadini.dev.notifichedigitali.it",
@@ -47,7 +49,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 			},
 			body: JSON.stringify({
 				email: "test@email.com",
-				traceId,
+				data
 			}),
 		};
 
@@ -56,7 +58,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 
 		expect(response.statusCode).to.equal(200);
 		expect(body.return_to).to.equal(
-			`${helpCenterUrl}?product=${productId}&data=${traceId}`
+			`${helpCenterUrl}?product=${productId}&data=${encodeURIComponent(JSON.stringify(data))}`
 		);
 	});
 

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -37,6 +37,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 	});
 
 	it("should include data in return_to when data is provided", async () => {
+		const traceId = '1-67bf00c8-35bf5bec6440ab13382ad7ee';
 		const event = {
 			headers: {
 				origin: "https://cittadini.dev.notifichedigitali.it",
@@ -46,7 +47,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 			},
 			body: JSON.stringify({
 				email: "test@email.com",
-				data: "test-data",
+				data: traceId,
 			}),
 		};
 
@@ -55,7 +56,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 
 		expect(response.statusCode).to.equal(200);
 		expect(body.return_to).to.equal(
-			`${helpCenterUrl}?product=${productId}&data=test-data`
+			`${helpCenterUrl}?product=${productId}&data=${traceId}`
 		);
 	});
 

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -1,110 +1,82 @@
 const { expect } = require("chai");
 const sinon = require("sinon");
 const utils = require("../app/utils");
-
 const { handleEvent } = require("../app/eventHandler");
 
 describe("Test zendeskAuthorizer eventHandler", () => {
-	let originalGenerateToken;
+    let originalGenerateToken;
+    const helpCenterUrl = process.env.HELP_CENTER_URL;
+    const productId = process.env.PRODUCT_ID;
 
-	const helpCenterUrl = process.env.HELP_CENTER_URL;
-	const productId = process.env.PRODUCT_ID;
+    beforeEach(() => {
+        originalGenerateToken = utils.generateToken;
+        sinon.stub(utils, "isTrustedOrigin").returns(true);
+        // Stub generateToken
+        sinon
+            .stub(utils, "generateToken")
+            .callsFake((name, email, taxId, zendeskSecret) => {
+                const forcedName = "Leonardo Da Vinci";
+                const forcedTaxId = "DVNLRD52D15M059P";
+                const forcedSecret = "fakeSecret";
+                return originalGenerateToken(
+                    forcedName,
+                    email,
+                    forcedTaxId,
+                    forcedSecret
+                );
+            });
+    });
 
-	beforeEach(() => {
-		originalGenerateToken = utils.generateToken;
+    afterEach(() => {
+        sinon.restore();
+    });
 
-		sinon.stub(utils, "isTrustedOrigin").returns(true);
+    // Helper function to create test events
+    const createTestEvent = (email, data = null) => ({
+        headers: {
+            origin: "https://cittadini.dev.notifichedigitali.it",
+            "Content-Type": "application/json",
+            Authorization: "Bearer fakeBearer",
+        },
+        body: JSON.stringify({
+            email,
+            ...(data && { data })
+        }),
+    });
 
-		// Stub generateToken
-		sinon
-			.stub(utils, "generateToken")
-			.callsFake((name, email, taxId, zendeskSecret) => {
-				const forcedName = "Leonardo Da Vinci";
-				const forcedTaxId = "DVNLRD52D15M059P";
-				const forcedSecret = "fakeSecret";
+    const testDataScenarios = [
+        {
+            description: "should include data in return_to when data is provided - both traceId and errorCode",
+            data: {
+                traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee',
+                errorCode: 'PN_USERATTRIBUTES_RETRYLIMITVERIFICATIONCODE'
+            }
+        },
+        {
+            description: "should include data in return_to when data is provided - traceId only",
+            data: {
+                traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee'
+            }
+        },
+        {
+            description: "should not include data in return_to when data is not provided",
+            data: null
+        }
+    ];
 
-				return originalGenerateToken(
-					forcedName,
-					email,
-					forcedTaxId,
-					forcedSecret
-				);
-			});
-	});
-
-	afterEach(() => {
-		sinon.restore();
-	});
-
-	it("should include data in return_to when data is provided - both traceId and errorCode", async () => {
-		const data = {
-			traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee',
-			errorCode: 'PN_USERATTRIBUTES_RETRYLIMITVERIFICATIONCODE'
-		};
-		const event = {
-			headers: {
-				origin: "https://cittadini.dev.notifichedigitali.it",
-				"Content-Type": "application/json",
-				Authorization:
-					"Bearer fakeBearer",
-			},
-			body: JSON.stringify({
-				email: "test@email.com",
-				data
-			}),
-		};
-
-		const response = await handleEvent(event);
-		const body = JSON.parse(response.body);
-
-		expect(response.statusCode).to.equal(200);
-		expect(body.return_to).to.equal(
-			`${helpCenterUrl}?product=${productId}&data=${encodeURIComponent(JSON.stringify(data))}`
-		);
-	});
-
-	it("should include data in return_to when data is provided - traceId only", async () => {
-		const data = {
-			traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee'
-		};
-		const event = {
-			headers: {
-				origin: "https://cittadini.dev.notifichedigitali.it",
-				"Content-Type": "application/json",
-				Authorization:
-					"Bearer fakeBearer",
-			},
-			body: JSON.stringify({
-				email: "test@email.com",
-				data
-			}),
-		};
-
-		const response = await handleEvent(event);
-		const body = JSON.parse(response.body);
-
-		expect(response.statusCode).to.equal(200);
-		expect(body.return_to).to.equal(
-			`${helpCenterUrl}?product=${productId}&data=${encodeURIComponent(JSON.stringify(data))}`
-		);
-	});
-
-	it("should not include data in return_to when data is not provided", async () => {
-		const event = {
-			headers: {
-				origin: "https://cittadini.dev.notifichedigitali.it",
-				"Content-Type": "application/json",
-				Authorization: "Bearer fakeBearerToken",
-			},
-			body: JSON.stringify({
-				email: "test@email.com",
-			}),
-		};
-
-		const response = await handleEvent(event);
-		const body = JSON.parse(response.body);
-
-		expect(response.statusCode).to.equal(200);
-		expect(body.return_to).to.equal(`${helpCenterUrl}?product=${productId}`);
-	});
+    testDataScenarios.forEach(({ description, data }) => {
+        it(description, async () => {
+            const event = createTestEvent("test@email.com", data);
+            const response = await handleEvent(event);
+            const body = JSON.parse(response.body);
+            
+            expect(response.statusCode).to.equal(200);
+            
+            const expectedReturnTo = data 
+                ? `${helpCenterUrl}?product=${productId}&data=${encodeURIComponent(JSON.stringify(data))}`
+                : `${helpCenterUrl}?product=${productId}`;
+                
+            expect(body.return_to).to.equal(expectedReturnTo);
+        });
+    });
 });

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -42,7 +42,7 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 				origin: "https://cittadini.dev.notifichedigitali.it",
 				"Content-Type": "application/json",
 				Authorization:
-					"Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFhZmQ0ZjllLTRhYmMtNDkwOC04NzMxLWJmNGVhOGI2ZTA4YSJ9.eyJpYXQiOjE3MTAzMjQyMzEsImV4cCI6MTcxMDMyNzQzMSwidWlkIjoiNDE0N2I1NDctODdiOS00YTIzLTk0MjAtY2FjNTc3NTViMjZjIiwiaXNzIjoiaHR0cHM6Ly93ZWJhcGkuZGV2Lm5vdGlmaWNoZWRpZ2l0YWxpLml0IiwiYXVkIjoid2ViYXBpLmRldi5ub3RpZmljaGVkaWdpdGFsaS5pdCIsImp0aSI6Il9lMGQ4N2RkZWE3MDNhMjFmYzQ0NiJ9.dfgkCcagjdnNAakmjbB-YhgGuSd_DpFLd3s8HdWTtefA6pP8BT9BopYLJzBIduxwddQ2A0ac_n6gSTmSXQQg6FUbOtKL-AuCiHfQqXw6OYYw6jhJty86z5JlGuiulOVmUxqTsLYFI5AyFnac7fe_RiuMYZzeWfclUFBEPmYsGrQ-xvR7rlNO5nMYj9bL-2_91RofkBse3-1ITBBA5B9wTTO3sjRQHAEdCcih3Vl9eLatdSpR2VuOPuGBjw31BgiCcTScdtbfMkwdfhlEJdnKTdSrJsQp6hg3C4aPrcqDveOcqJjzo1R3JsIrhL_X5w8SBFasWsmQepMQFmZm2HNp1A",
+					"Bearer fakeBearer",
 			},
 			body: JSON.stringify({
 				email: "test@email.com",

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -36,7 +36,34 @@ describe("Test zendeskAuthorizer eventHandler", () => {
 		sinon.restore();
 	});
 
-	it("should include data in return_to when data is provided", async () => {
+	it("should include data in return_to when data is provided - both traceId and errorCode", async () => {
+		const data = {
+			traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee',
+			errorCode: 'PN_USERATTRIBUTES_RETRYLIMITVERIFICATIONCODE'
+		};
+		const event = {
+			headers: {
+				origin: "https://cittadini.dev.notifichedigitali.it",
+				"Content-Type": "application/json",
+				Authorization:
+					"Bearer fakeBearer",
+			},
+			body: JSON.stringify({
+				email: "test@email.com",
+				data
+			}),
+		};
+
+		const response = await handleEvent(event);
+		const body = JSON.parse(response.body);
+
+		expect(response.statusCode).to.equal(200);
+		expect(body.return_to).to.equal(
+			`${helpCenterUrl}?product=${productId}&data=${encodeURIComponent(JSON.stringify(data))}`
+		);
+	});
+
+	it("should include data in return_to when data is provided - traceId only", async () => {
 		const data = {
 			traceId: '1-67bf00c8-35bf5bec6440ab13382ad7ee'
 		};

--- a/functions/zendeskAuthorizer/src/test/eventHandler.test.js
+++ b/functions/zendeskAuthorizer/src/test/eventHandler.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+const utils = require("../app/utils");
+
+const { handleEvent } = require("../app/eventHandler");
+
+describe("Test zendeskAuthorizer eventHandler", () => {
+	let originalGenerateToken;
+
+	const helpCenterUrl = process.env.HELP_CENTER_URL;
+	const productId = process.env.PRODUCT_ID;
+
+	beforeEach(() => {
+		originalGenerateToken = utils.generateToken;
+
+		sinon.stub(utils, "isTrustedOrigin").returns(true);
+
+		// Stub generateToken
+		sinon
+			.stub(utils, "generateToken")
+			.callsFake((name, email, taxId, zendeskSecret) => {
+				const forcedName = "Leonardo Da Vinci";
+				const forcedTaxId = "DVNLRD52D15M059P";
+				const forcedSecret = "fakeSecret";
+
+				return originalGenerateToken(
+					forcedName,
+					email,
+					forcedTaxId,
+					forcedSecret
+				);
+			});
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it("should include data in return_to when data is provided", async () => {
+		const event = {
+			headers: {
+				origin: "https://cittadini.dev.notifichedigitali.it",
+				"Content-Type": "application/json",
+				Authorization:
+					"Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFhZmQ0ZjllLTRhYmMtNDkwOC04NzMxLWJmNGVhOGI2ZTA4YSJ9.eyJpYXQiOjE3MTAzMjQyMzEsImV4cCI6MTcxMDMyNzQzMSwidWlkIjoiNDE0N2I1NDctODdiOS00YTIzLTk0MjAtY2FjNTc3NTViMjZjIiwiaXNzIjoiaHR0cHM6Ly93ZWJhcGkuZGV2Lm5vdGlmaWNoZWRpZ2l0YWxpLml0IiwiYXVkIjoid2ViYXBpLmRldi5ub3RpZmljaGVkaWdpdGFsaS5pdCIsImp0aSI6Il9lMGQ4N2RkZWE3MDNhMjFmYzQ0NiJ9.dfgkCcagjdnNAakmjbB-YhgGuSd_DpFLd3s8HdWTtefA6pP8BT9BopYLJzBIduxwddQ2A0ac_n6gSTmSXQQg6FUbOtKL-AuCiHfQqXw6OYYw6jhJty86z5JlGuiulOVmUxqTsLYFI5AyFnac7fe_RiuMYZzeWfclUFBEPmYsGrQ-xvR7rlNO5nMYj9bL-2_91RofkBse3-1ITBBA5B9wTTO3sjRQHAEdCcih3Vl9eLatdSpR2VuOPuGBjw31BgiCcTScdtbfMkwdfhlEJdnKTdSrJsQp6hg3C4aPrcqDveOcqJjzo1R3JsIrhL_X5w8SBFasWsmQepMQFmZm2HNp1A",
+			},
+			body: JSON.stringify({
+				email: "test@email.com",
+				data: "test-data",
+			}),
+		};
+
+		const response = await handleEvent(event);
+		const body = JSON.parse(response.body);
+
+		expect(response.statusCode).to.equal(200);
+		expect(body.return_to).to.equal(
+			`${helpCenterUrl}?product=${productId}&data=test-data`
+		);
+	});
+
+	it("should not include data in return_to when data is not provided", async () => {
+		const event = {
+			headers: {
+				origin: "https://cittadini.dev.notifichedigitali.it",
+				"Content-Type": "application/json",
+				Authorization: "Bearer fakeBearerToken",
+			},
+			body: JSON.stringify({
+				email: "test@email.com",
+			}),
+		};
+
+		const response = await handleEvent(event);
+		const body = JSON.parse(response.body);
+
+		expect(response.statusCode).to.equal(200);
+		expect(body.return_to).to.equal(`${helpCenterUrl}?product=${productId}`);
+	});
+});


### PR DESCRIPTION
## Short description
This PR includes the changes needed to support an optional "data" param to be included inside the "return_to" url.
This information is received inside the body request and passed back into the consequent response as query param of the 'return_to' url.
This param is used by the frontend to send the traceId related to a request which thrown an exeption to the support team.

## List of changes proposed in this pull request
feat: add optional property 'data' for NewSupportRequest model into openapi
feat: add 'data' as query param inside 'return_to' url after receiving it inside the request body
feat: add tests to verify that 'return_to' url is properly build if 'data' is either received or not